### PR TITLE
Parser add unRegister method

### DIFF
--- a/src/Input/Parser.php
+++ b/src/Input/Parser.php
@@ -247,6 +247,25 @@ abstract class Parser
 
         $this->set($name, $param->default());
     }
+    /**
+     * 
+     * @param string $name
+     */
+    public function unRegister($name)
+    {
+        if(isset($this->_values[$name])){
+            unset($this->_values[$name]);
+        }
+        
+        if(isset($this->_arguments[$name])){
+            unset($this->_arguments[$name]);
+        }
+        
+        if(isset($this->_options[$name])){
+            unset($this->_options[$name]);
+        }
+        return $this;
+    }
 
     /**
      * What if the given name is already registered.

--- a/src/Input/Parser.php
+++ b/src/Input/Parser.php
@@ -249,11 +249,11 @@ abstract class Parser
     }
 
     /**
-     * unRegister a new argument/option.
+     * unset a registered argument/option.
      *
      * @param string $name
      */
-    public function unRegister($name)
+    public function unset($name)
     {
         unset($this->_values[$name], $this->_arguments[$name], $this->_options[$name]);
 

--- a/src/Input/Parser.php
+++ b/src/Input/Parser.php
@@ -247,25 +247,15 @@ abstract class Parser
 
         $this->set($name, $param->default());
     }
-    
+
     /**
      * unRegister a new argument/option.
-     * 
+     *
      * @param string $name
      */
     public function unRegister($name)
     {
-        if (isset($this->_values[$name])) {
-            unset($this->_values[$name]);
-        }
-
-        if (isset($this->_arguments[$name])) {
-            unset($this->_arguments[$name]);
-        }
-
-        if (isset($this->_options[$name])) {
-            unset($this->_options[$name]);
-        }
+        unset($this->_values[$name], $this->_arguments[$name], $this->_options[$name]);
 
         return $this;
     }

--- a/src/Input/Parser.php
+++ b/src/Input/Parser.php
@@ -248,22 +248,23 @@ abstract class Parser
         $this->set($name, $param->default());
     }
     /**
-     * 
+     * unRegister a new argument/option.
      * @param string $name
      */
     public function unRegister($name)
     {
-        if(isset($this->_values[$name])){
+        if (isset($this->_values[$name])) {
             unset($this->_values[$name]);
         }
-        
-        if(isset($this->_arguments[$name])){
+
+        if (isset($this->_arguments[$name])) {
             unset($this->_arguments[$name]);
         }
-        
-        if(isset($this->_options[$name])){
+
+        if (isset($this->_options[$name])) {
             unset($this->_options[$name]);
         }
+
         return $this;
     }
 

--- a/src/Input/Parser.php
+++ b/src/Input/Parser.php
@@ -247,8 +247,10 @@ abstract class Parser
 
         $this->set($name, $param->default());
     }
+    
     /**
      * unRegister a new argument/option.
+     * 
      * @param string $name
      */
     public function unRegister($name)

--- a/tests/Input/CommandTest.php
+++ b/tests/Input/CommandTest.php
@@ -261,6 +261,16 @@ class CommandTest extends TestCase
         $this->assertNull($c->app());
     }
 
+    public function test_unregister()
+    {
+        $c = $this->newCommand();
+        $this->assertCount(3,$c->allOptions());
+        $this->assertArrayHasKey('verbosity', $c->allOptions());
+        $c->unRegister('verbosity');
+        $this->assertCount(2,$c->allOptions());
+        $this->assertArrayNotHasKey('verbosity', $c->allOptions());
+    }
+    
     protected function newCommand(string $version = '0.0.1', string $desc = '', bool $allowUnknown = false, $app = null)
     {
         $p = new Command('cmd', $desc, $allowUnknown, $app);

--- a/tests/Input/CommandTest.php
+++ b/tests/Input/CommandTest.php
@@ -264,13 +264,13 @@ class CommandTest extends TestCase
     public function test_unregister()
     {
         $c = $this->newCommand();
-        $this->assertCount(3,$c->allOptions());
+        $this->assertCount(3, $c->allOptions());
         $this->assertArrayHasKey('verbosity', $c->allOptions());
         $c->unRegister('verbosity');
-        $this->assertCount(2,$c->allOptions());
+        $this->assertCount(2, $c->allOptions());
         $this->assertArrayNotHasKey('verbosity', $c->allOptions());
     }
-    
+
     protected function newCommand(string $version = '0.0.1', string $desc = '', bool $allowUnknown = false, $app = null)
     {
         $p = new Command('cmd', $desc, $allowUnknown, $app);

--- a/tests/Input/CommandTest.php
+++ b/tests/Input/CommandTest.php
@@ -261,12 +261,12 @@ class CommandTest extends TestCase
         $this->assertNull($c->app());
     }
 
-    public function test_unregister()
+    public function test_unset()
     {
         $c = $this->newCommand();
         $this->assertCount(3, $c->allOptions());
         $this->assertArrayHasKey('verbosity', $c->allOptions());
-        $c->unRegister('verbosity');
+        $c->unset('verbosity');
         $this->assertCount(2, $c->allOptions());
         $this->assertArrayNotHasKey('verbosity', $c->allOptions());
     }


### PR DESCRIPTION
Add the unRegister method to unRegister

I had a situation in development where I needed to unregister but _options was private so I couldn't unregister, so I added this.