### PR TITLE
Correct io() fallback mechanism

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -40,8 +40,8 @@ class Application
 
     protected string $default = '__default__';
 
-    /** @var Interactor */
-    protected Interactor $io;
+    /** @var null|Interactor */
+    protected ?Interactor $io = null;
 
     /** @var callable The callable to perform exit */
     protected $onExit;

--- a/tests/ApplicationTest.php
+++ b/tests/ApplicationTest.php
@@ -251,6 +251,16 @@ class ApplicationTest extends TestCase
         $this->assertStringContainsString('Did you mean cmd?', $o);
     }
 
+    public function test_io_returns_new_instance_if_not_provided(): void
+    {
+        $app = new Application('some-name', '0.0.1', fn () => false);
+
+        $this->assertInstanceOf(
+            Interactor::class,
+            $app->io()
+        );
+    }
+
     protected function newApp(string $name, string $version = '')
     {
         $app = new Application($name, $version ?: '0.0.1', function () {


### PR DESCRIPTION
If no Interactor has been provided in the first place, `io()` has a
fallback in which it creates a new Interactor instance from scratch.
Since the addition of php8 types in c94535f15e2d7617b98507876017a46bb99325dd,
this fails because of a missing default value for the io-property.

This adds a default `null` value to the property to make the property
check in `io()` work again.