### PR TITLE
Had issues on windows - fixed them + added custom descriptors support to Shell

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ composer.lock
 clover.xml
 coverage.xml
 phpcs.xml
+.phpunit.result.cache

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -6,7 +6,7 @@
  convertErrorsToExceptions="true"
  convertNoticesToExceptions="true"
  convertWarningsToExceptions="true"
- processIsolation="false"
+ processIsolation="true"
  stopOnFailure="false"
  bootstrap="tests/bootstrap.php"
  xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">

--- a/tests/ApplicationTest.php
+++ b/tests/ApplicationTest.php
@@ -24,8 +24,8 @@ class ApplicationTest extends TestCase
 
     public function setUp(): void
     {
-        file_put_contents(static::$in, '');
-        file_put_contents(static::$ou, '');
+        file_put_contents(static::$in, '', LOCK_EX);
+        file_put_contents(static::$ou, '', LOCK_EX);
     }
 
     public function tearDown(): void

--- a/tests/ApplicationTest.php
+++ b/tests/ApplicationTest.php
@@ -30,8 +30,13 @@ class ApplicationTest extends TestCase
 
     public function tearDown(): void
     {
-        unlink(static::$in);
-        unlink(static::$ou);
+        // Make sure we clean up after ourselves:
+        if (file_exists(static::$in)) {
+            unlink(static::$in);
+        }
+        if (file_exists(static::$ou)) {
+            unlink(static::$ou);
+        }
     }
 
     public function test_new()

--- a/tests/CliTestCase.php
+++ b/tests/CliTestCase.php
@@ -36,7 +36,7 @@ class CliTestCase extends TestCase
     {
         ob_start();
         StreamInterceptor::$buffer = '';
-        file_put_contents(static::$ou, '');
+        file_put_contents(static::$ou, '', LOCK_EX);
     }
 
     public function tearDown(): void

--- a/tests/CliTestCase.php
+++ b/tests/CliTestCase.php
@@ -46,7 +46,10 @@ class CliTestCase extends TestCase
 
     public static function tearDownAfterClass(): void
     {
-        unlink(static::$ou);
+        // Make sure we clean up after ourselves:
+        if (file_exists(static::$ou)) {
+            unlink(static::$ou);
+        }
     }
 
     public function buffer()

--- a/tests/Helper/OutputHelperTest.php
+++ b/tests/Helper/OutputHelperTest.php
@@ -34,7 +34,10 @@ class OutputHelperTest extends TestCase
 
     public static function tearDownAfterClass(): void
     {
-        unlink(static::$ou);
+        // Make sure we clean up after ourselves:
+        if (file_exists(static::$ou)) {
+            unlink(static::$ou);
+        }
     }
 
     public function test_show_arguments()

--- a/tests/Helper/OutputHelperTest.php
+++ b/tests/Helper/OutputHelperTest.php
@@ -29,7 +29,7 @@ class OutputHelperTest extends TestCase
 
     public function setUp(): void
     {
-        file_put_contents(static::$ou, '');
+        file_put_contents(static::$ou, '', LOCK_EX);
     }
 
     public static function tearDownAfterClass(): void

--- a/tests/Helper/ShellTest.php
+++ b/tests/Helper/ShellTest.php
@@ -24,7 +24,7 @@ class ShellTest extends TestCase
 
         $shell->execute();
 
-        $this->assertSame("hello\n", $shell->getOutput());
+        $this->assertSame("hello", trim($shell->getOutput())); // trim to remove trailing newline which is OS dependent
         $this->assertSame(0, $shell->getExitCode());
     }
 
@@ -35,7 +35,7 @@ class ShellTest extends TestCase
         $shell->execute(true);
 
         $this->assertIsInt($pid = $shell->getProcessId());
-        $this->assertGreaterThan(getmypid(), $pid);
+        // $this->assertGreaterThan(getmypid(), $pid); // this is not always true especially on windows
     }
 
     public function test_async_stop()

--- a/tests/IO/InteractorTest.php
+++ b/tests/IO/InteractorTest.php
@@ -24,8 +24,8 @@ class InteractorTest extends TestCase
 
     public function setUp(): void
     {
-        file_put_contents(static::$in, '');
-        file_put_contents(static::$ou, '');
+        file_put_contents(static::$in, '', LOCK_EX);
+        file_put_contents(static::$ou, '', LOCK_EX);
     }
 
     public function tearDown(): void
@@ -152,7 +152,7 @@ class InteractorTest extends TestCase
 
     protected function newInteractor(string $in = '')
     {
-        file_put_contents(static::$in, $in);
+        file_put_contents(static::$in, $in, LOCK_EX);
 
         return new Interactor(static::$in, static::$ou);
     }

--- a/tests/IO/InteractorTest.php
+++ b/tests/IO/InteractorTest.php
@@ -30,8 +30,13 @@ class InteractorTest extends TestCase
 
     public function tearDown(): void
     {
-        unlink(static::$in);
-        unlink(static::$ou);
+        // Make sure we clean up after ourselves:
+        if (file_exists(static::$in)) {
+            unlink(static::$in);
+        }
+        if (file_exists(static::$ou)) {
+            unlink(static::$ou);
+        }
     }
 
     public function test_components()

--- a/tests/Input/ReaderTest.php
+++ b/tests/Input/ReaderTest.php
@@ -26,7 +26,10 @@ class ReaderTest extends TestCase
 
     public static function tearDownAfterClass(): void
     {
-        unlink(static::$in);
+        // Make sure we clean up after ourselves:
+        if (file_exists(static::$in)) {
+            unlink(static::$in);
+        }
     }
 
     public function test_default()

--- a/tests/Input/ReaderTest.php
+++ b/tests/Input/ReaderTest.php
@@ -21,7 +21,7 @@ class ReaderTest extends TestCase
 
     public function setUp(): void
     {
-        file_put_contents(static::$in, '');
+        file_put_contents(static::$in, '', LOCK_EX);
     }
 
     public static function tearDownAfterClass(): void
@@ -38,7 +38,7 @@ class ReaderTest extends TestCase
 
     public function test_callback()
     {
-        file_put_contents(static::$in, 'the value');
+        file_put_contents(static::$in, 'the value', LOCK_EX);
 
         $r = new Reader(static::$in);
 

--- a/tests/Output/ColorTest.php
+++ b/tests/Output/ColorTest.php
@@ -52,12 +52,13 @@ class ColorTest extends TestCase
     {
         $c = new Color;
 
-        $this->assertSame("\nabc\n", $c->colors('<eol>abc</eol>'));
+        // We use PHP_EOL here because it is platform dependent and eol tag will be replaced by it.
+        $this->assertSame(PHP_EOL."abc".PHP_EOL, $c->colors('<eol>abc</eol>'));
         $this->assertSame("\033[0;31mRed\033[0m", $c->colors('<red>Red</end>'));
-        $this->assertSame("\033[1;31mBoldRed\n\033[0m", $c->colors('<boldRed>BoldRed<eol/></end>'));
-        $this->assertSame("\033[0;36;42mBgGreenCyan\033[0m\n", $c->colors('<bgGreenCyan>BgGreenCyan</end><eol>'));
+        $this->assertSame("\033[1;31mBoldRed".PHP_EOL."\033[0m", $c->colors('<boldRed>BoldRed<eol/></end>'));
+        $this->assertSame("\033[0;36;42mBgGreenCyan\033[0m".PHP_EOL, $c->colors('<bgGreenCyan>BgGreenCyan</end><eol>'));
         $this->assertSame(
-            "\033[0;31mRed\033[0m\nNormal\n\033[1;37mBOLD\033[0m",
+            "\033[0;31mRed\033[0m".PHP_EOL."Normal".PHP_EOL."\033[1;37mBOLD\033[0m",
             $c->colors("<red>Red</end>\r\nNormal\n<bold>BOLD</end>")
         );
     }


### PR DESCRIPTION
### Summary:
- Tests were failing on windows mainly because 'phpunit' was firing multiple attempts to read / write to the same files without locking.
- Fixed `Colors` tests which were comparing `\n` to `PHP_EOL` - which is not reliable and fails on windows.
- Safer `unlink` in tests to avoid warnings.
- Shell was using a NUL file descriptor of `stdout` and `stderr` - changed that and added support for "custom" pipes declaration passed to `execute()`.
- Improved `isWindows()` in `Shell`
- Safer reading, writing and closing of pipes in `Shell` - checks to see they are a viable resource.

Tested it again passing all tests on windows and linux... ✔️ 
🚦 **PLEASE** - add a new release, 1.2 is the latest and doesn't include the `$env` bug fix which was merged later. 

🚀 Great project - lightweight, clean and neat