### PR TITLE
Added defaultCommand and getDefaultCommand methods

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -175,6 +175,37 @@ class Application
     }
 
     /**
+     * Set the default command.
+     *
+     * @param string $commandName The name of the default command
+     *
+     * @return self The application
+     *
+     * @throws InvalidArgumentException If the specified command name does not exist
+     */
+    public function defaultCommand(string $commandName): self
+    {
+        if (!isset($this->commands[$commandName])) {
+            throw new InvalidArgumentException(sprintf('Command "%s" does not exist', $commandName));
+        }
+
+        $this->default = $commandName;
+
+        return $this;
+    }
+
+    /**
+     * Get the default command.
+     *
+     * @return string|null The name of the default command, or null if not set
+     */
+    public function getDefaultCommand(): ?string
+    {
+        return $this->default;
+    }
+
+
+    /**
      * Groups commands set within the callable.
      *
      * @param string   $group The group name

--- a/tests/ApplicationTest.php
+++ b/tests/ApplicationTest.php
@@ -305,4 +305,21 @@ class ApplicationTest extends TestCase
 
         return $app->io(new Interactor(static::$in, static::$ou));
     }
+
+    public function testDefaultCommand()
+    {
+        $app = $this->newApp("test");
+
+        // Add some sample commands to the application
+        $app->command('command1');
+        $app->command('command2');
+
+        // Test setting a valid default command
+        $app->defaultCommand('command1');
+        $this->assertEquals('command1', $app->getDefaultCommand());
+
+        // Test setting an invalid default command
+        $this->expectException(InvalidArgumentException::class);
+        $app->defaultCommand('invalid_command');
+    }
 }


### PR DESCRIPTION
I add two new methods, **defaultCommand** and **getDefaultCommand**, to the Application class. These methods allow for setting and retrieving the default command of the application.

- The **defaultCommand** method sets the default command by accepting the name of the command as a parameter. It throws an `InvalidArgumentException` if the specified command name does not exist in the application.

- The **getDefaultCommand** method returns the name of the default command if it is set, or null if no default command is set.

These methods provide more flexibility and control over the default command behavior in the application.

Please review this pull request at your convenience. Thank you.