### PR TITLE
patch: Adding new options to the progressbar 

### DIFF
--- a/README.md
+++ b/README.md
@@ -505,14 +505,16 @@ $progress->option([
 ]);
 
 // Available options
-+------------+------------------------------+---------------+
-| Option     | Description                  | Default value |
-+------------+------------------------------+---------------+
-| pointer    | The progress bar head symbol | >             |
-| loader     | The loader symbol            | =             |
-| color      | The color of progress bar    | white         |
-| labelColor | The text color of the label  | white         |
-+------------+------------------------------+---------------+
++---------------+------------------------------------------------------+---------------+
+| Option        | Description                                          | Default value |
++===============+======================================================+===============+
+| pointer       | The progress bar head symbol                         | >             |
+| loader        | The loader symbol                                    | =             |
+| color         | The color of progress bar                            | white         |
+| labelColor    | The text color of the label                          | white         |
+| labelPosition | The position of the label (top, bottom, left, right) | bottom        |
++---------------+------------------------------------------------------+---------------+
+
 ```
 
 ### Writer

--- a/src/Output/ProgressBar.php
+++ b/src/Output/ProgressBar.php
@@ -70,7 +70,8 @@ class ProgressBar
         'color'          => 'white',
         'labelColor'     => 'white',
         'labelPosition'  => 'bottom',
-        'showPercentage' => true,       // in spinner mode, you may not want to display the percentage of the progress because you don't know in advance how long the processing will take (during an asynchronous call for example)
+        // in spinner/async mode, you may hide the progress percentage as you won't know in advance how long it will take
+        'showPercentage' => true,
     ];
 
     /**

--- a/src/Output/ProgressBar.php
+++ b/src/Output/ProgressBar.php
@@ -338,20 +338,20 @@ class ProgressBar
         $progress = [];
         if ($this->options['labelPosition'] === 'left') {
             // display : ====>       Label 50%
-            $progress[] = '<' . $this->options['color'] . '>' . $bar . '</end> '; // bar
-            $progress[] = '<' . $this->options['labelColor'] . '>' . $label . '</end> '; // label
-            $progress[] = '<' . $this->options['color'] . '>' . $number . '</end>'; // percentage
+            $progress[] = '<' . $this->options['color'] . '>' . $bar . '</end> ';
+            $progress[] = '<' . $this->options['labelColor'] . '>' . $label . '</end> ';
+            $progress[] = '<' . $this->options['color'] . '>' . $number . '</end>';
         } else if ($this->options['labelPosition'] === 'top') {
             // display :Label
             //          ====>        50%
-            $progress[] = '<' . $this->options['labelColor'] . '>' . $label . "\n" . '</end>'; // label
+            $progress[] = '<' . $this->options['labelColor'] . '>' . $label . "\n" . '</end>';
             $progress[] = '<' . $this->options['color'] . '>' . $bar . ' ' . $number . '</end>'; // bar + percentage
         } else {
             // display (on right) : ====>       50% Label
             // display (on bottom): ====>       50%
             //                      Label
             $progress[] = '<' . $this->options['color'] . '>' . $bar . ' ' . $number . '</end> '; // bar + percentage
-            $progress[] = '<' . $this->options['labelColor'] . '>' . $label . '</end>'; // label
+            $progress[] = '<' . $this->options['labelColor'] . '>' . $label . '</end>';
         }
 
         return implode('', $progress);

--- a/src/Output/ProgressBar.php
+++ b/src/Output/ProgressBar.php
@@ -69,7 +69,7 @@ class ProgressBar
         'loader'         => '=',
         'color'          => 'white',
         'labelColor'     => 'white',
-        'labelPosition'  => 'bottom',   // position of the label according to the progress bar (one of 'top', 'bottom', 'left', 'right')
+        'labelPosition'  => 'bottom',
         'showPercentage' => true,       // in spinner mode, you may not want to display the percentage of the progress because you don't know in advance how long the processing will take (during an asynchronous call for example)
     ];
 
@@ -331,7 +331,7 @@ class ProgressBar
      */
     protected function progressBarFormatted(string $bar, string $number, string $label): string
     {
-        if ($this->options['showPercentage'] !== true) {
+        if (! $this->options['showPercentage']) {
             $number = '';
         }
 

--- a/src/Output/ProgressBar.php
+++ b/src/Output/ProgressBar.php
@@ -70,6 +70,7 @@ class ProgressBar
         'color'          => 'white',
         'labelColor'     => 'white',
         'labelPosition'  => 'bottom',   // position of the label according to the progress bar (one of 'top', 'bottom', 'left', 'right')
+        'showPercentage' => true,       // in spinner mode, you may not want to display the percentage of the progress because you don't know in advance how long the processing will take (during an asynchronous call for example)
     ];
 
     /**
@@ -113,6 +114,18 @@ class ProgressBar
     }
 
     /**
+     * Set the string length of the bar when at 100%.
+     *
+     * @internal use by Spinner
+     */
+    public function barWidth(int $size): self
+    {
+        $this->barStrLen = max(1, $size);
+
+        return $this;
+    }
+
+    /**
      * Set progress bar options.
      */
     public function option(string|array $key, ?string $value = null): self
@@ -128,6 +141,14 @@ class ProgressBar
         $this->options = array_merge($this->options, $key);
 
         return $this;
+    }
+
+    /**
+     * Force end of progress
+     */
+    public function finish(): void
+    {
+        $this->current = $this->total;
     }
 
     /**
@@ -310,6 +331,10 @@ class ProgressBar
      */
     protected function progressBarFormatted(string $bar, string $number, string $label): string
     {
+        if ($this->options['showPercentage'] !== true) {
+            $number = '';
+        }
+
         $progress = [];
         if ($this->options['labelPosition'] === 'left') {
             // display : ====>       Label 50%


### PR DESCRIPTION
- Ability to change label location: previously, the label was always placed at the bottom of the progressbar. This pull request lets dev choose where to place it
- Possibility of hiding the progress percentage: originally, I'd designed it to be used internally by the spinner (since we didn't need it in the spinner), but given that the spinner is a complex subject (see https://github.com/adhocore/php-cli/pull/89) perhaps we could come back to it. Nevertheless, I think it could be useful in a classic case, which is why I've kept it.