### PR TITLE
fix dynamic property deprecation notice in testsuite on php 8.3

### DIFF
--- a/src/Output/Writer.php
+++ b/src/Output/Writer.php
@@ -322,7 +322,8 @@ class Writer
         ];
 
         $second    = (string) $second;
-        $dashWidth = $this->terminal->width() - (strlen($first) + strlen($second));
+        $terminalWidth = $this->terminal->width() ?? 80;
+        $dashWidth = $terminalWidth - (strlen($first) + strlen($second));
         // remove left and right margins because we're going to add 1 space on each side (after/before the text).
         // if we don't have a second element, we just remove the left margin
         $dashWidth -= $second === '' ? 1 : 2;

--- a/tests/ApplicationTest.php
+++ b/tests/ApplicationTest.php
@@ -22,6 +22,7 @@ class ApplicationTest extends TestCase
 {
     protected static $in = __DIR__ . '/input.test';
     protected static $ou = __DIR__ . '/output.test';
+    private bool $actionCalled;
 
     public function setUp(): void
     {

--- a/tests/Output/WriterTest.php
+++ b/tests/Output/WriterTest.php
@@ -122,6 +122,15 @@ class WriterTest extends CliTestCase
     {
         $w = new Writer(static::$ou);
 
+        $terminal = $this->createMock(Terminal::class);
+        $terminal->expects($this->once())
+            ->method('width')
+            ->willReturn(80);
+
+        $reflection = new \ReflectionProperty(Writer::class, 'terminal');
+        $reflection->setAccessible(true);
+        $reflection->setValue($w, $terminal);
+
         $w->justify('PHP Version', PHP_VERSION, [
             'sep' => '-',
         ]);


### PR DESCRIPTION
ApplicationTest::test_array_action() uses the dynamic property $actionCalled, which is not registered in the testclass. on 8.3 this throws a depecration notice, this small pr fixes that.