### PR TITLE
Allow for custom default command execution without arguments

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -308,7 +308,7 @@ class Application
      */
     public function handle(array $argv): mixed
     {
-        if (count($argv) < 2) {
+        if ($this->default === '__default__' && count($argv) < 2) {
             return $this->showHelp();
         }
 

--- a/tests/ApplicationTest.php
+++ b/tests/ApplicationTest.php
@@ -313,7 +313,7 @@ class ApplicationTest extends TestCase
 
         // Add some sample commands to the application
         $app->command('command1')->action(function () {
-          echo 'This should be the default command';
+            echo 'This should be the default command';
         });
         $app->command('command2');
 

--- a/tests/ApplicationTest.php
+++ b/tests/ApplicationTest.php
@@ -312,12 +312,20 @@ class ApplicationTest extends TestCase
         $app = $this->newApp('test');
 
         // Add some sample commands to the application
-        $app->command('command1');
+        $app->command('command1')->action(function () {
+          echo 'This should be the default command';
+        });
         $app->command('command2');
 
         // Test setting a valid default command
         $app->defaultCommand('command1');
         $this->assertEquals('command1', $app->getDefaultCommand());
+
+        // Test executing a default command
+        ob_start();
+        $app->handle(['test']);
+        $buffer = ob_get_clean();
+        $this->assertSame('This should be the default command', $buffer);
 
         // Test setting an invalid default command
         $this->expectException(InvalidArgumentException::class);


### PR DESCRIPTION
Currently, if you set a custom default command and then try to run it without passing it any arguments, the help screen will be displayed just like it would have if we never set a custom default command.

This small PR makes it so that your default command can be ran without passing it any arguments.