### PR TITLE
Table with unicode character

### DIFF
--- a/src/Helper/InflectsString.php
+++ b/src/Helper/InflectsString.php
@@ -12,7 +12,11 @@
 namespace Ahc\Cli\Helper;
 
 use function lcfirst;
+use function mb_strwidth;
+use function mb_substr;
 use function str_replace;
+use function strlen;
+use function substr;
 use function trim;
 use function ucwords;
 
@@ -46,5 +50,29 @@ trait InflectsString
         $words = trim(str_replace(['-', '_'], ' ', $string));
 
         return ucwords($words);
+    }
+
+    /**
+     * Return width of string
+     */
+    public function strwidth(string $string): int
+    {
+        if (function_exists('mb_strwidth')) {
+            return mb_strwidth($string);
+        }
+
+        return strlen($string);
+    }
+
+    /**
+     * Get part of string
+     */
+    public function substr(string $string, int $start, ?int $length = null): string
+    {
+        if (function_exists('mb_substr')) {
+            return mb_substr($string, $start, $length);
+        }
+
+        return substr($string, $start, $length);
     }
 }

--- a/src/Output/Table.php
+++ b/src/Output/Table.php
@@ -23,8 +23,6 @@ use function gettype;
 use function implode;
 use function is_array;
 use function max;
-use function mb_strwidth;
-use function mb_substr;
 use function reset;
 use function sprintf;
 use function str_repeat;
@@ -84,7 +82,7 @@ class Table
                     $word = str_replace($matches[1], '', $text);
                     $word = preg_replace('/\\x1b\[0m/', '', $word);
 
-                    $size += mb_strwidth($text) - mb_strwidth($word);
+                    $size += $this->strwidth($text) - $this->strwidth($word);
                 }
 
                 $parts[] = "$start " . $this->strPad($text, $size, ' ') . " $end";
@@ -131,8 +129,8 @@ class Table
                 return $col;
             }, $cols);
 
-            $span   = array_map('mb_strwidth', $cols);
-            $span[] = mb_strwidth($col);
+            $span   = array_map([$this, 'strwidth'], $cols);
+            $span[] = $this->strwidth($col);
             $value  = max($span);
         }
 
@@ -182,10 +180,10 @@ class Table
      */
     protected function strPad(string $string, int $length, string $pad_string = ' '): string
     {
-        if (1 > $paddingRequired = $length - mb_strwidth($string)) {
+        if (1 > $paddingRequired = $length - $this->strwidth($string)) {
             return $string;
         }
 
-        return $string . mb_substr(str_repeat($pad_string, $paddingRequired), 0, $paddingRequired);
+        return $string . $this->substr(str_repeat($pad_string, $paddingRequired), 0, $paddingRequired);
     }
 }

--- a/src/Output/Table.php
+++ b/src/Output/Table.php
@@ -23,11 +23,11 @@ use function gettype;
 use function implode;
 use function is_array;
 use function max;
+use function mb_strwidth;
+use function mb_substr;
 use function reset;
 use function sprintf;
-use function str_pad;
 use function str_repeat;
-use function strlen;
 use function trim;
 
 use const PHP_EOL;
@@ -51,7 +51,7 @@ class Table
         $pos           = 0;
         foreach ($head as $col => $size) {
             $dash[]          = str_repeat('-', $size + 2);
-            $title[]         = str_pad($this->toWords($col), $size, ' ');
+            $title[]         = $this->strPad($this->toWords($col), $size, ' ');
             $positions[$col] = ++$pos;
         }
 
@@ -62,7 +62,6 @@ class Table
             $parts = [];
             $line++;
 
-            [$start, $end] = $styles[['even', 'odd'][(int) $odd]];
             foreach ($head as $col => $size) {
                 $colNumber = $positions[$col];
 
@@ -85,10 +84,10 @@ class Table
                     $word = str_replace($matches[1], '', $text);
                     $word = preg_replace('/\\x1b\[0m/', '', $word);
 
-                    $size += strlen($text) - strlen($word);
+                    $size += mb_strwidth($text) - mb_strwidth($word);
                 }
 
-                $parts[] = "$start " . str_pad($text, $size, ' ') . " $end";
+                $parts[] = "$start " . $this->strPad($text, $size, ' ') . " $end";
             }
 
             $odd    = !$odd;
@@ -132,8 +131,8 @@ class Table
                 return $col;
             }, $cols);
 
-            $span   = array_map('strlen', $cols);
-            $span[] = strlen($col);
+            $span   = array_map('mb_strwidth', $cols);
+            $span[] = mb_strwidth($col);
             $value  = max($span);
         }
 
@@ -176,5 +175,17 @@ class Table
         }
 
         return ['', ''];
+    }
+
+    /**
+     * Pad a multibyte string to a certain length with another multibyte string
+     */
+    protected function strPad(string $string, int $length, string $pad_string = ' '): string
+    {
+        if (1 > $paddingRequired = $length - mb_strwidth($string)) {
+            return $string;
+        }
+
+        return $string . mb_substr(str_repeat($pad_string, $paddingRequired), 0, $paddingRequired);
     }
 }

--- a/src/Output/Writer.php
+++ b/src/Output/Writer.php
@@ -11,6 +11,7 @@
 
 namespace Ahc\Cli\Output;
 
+use Ahc\Cli\Helper\InflectsString;
 use Ahc\Cli\Helper\Terminal;
 
 use function fopen;
@@ -19,7 +20,6 @@ use function max;
 use function method_exists;
 use function str_repeat;
 use function stripos;
-use function strlen;
 use function strpos;
 use function ucfirst;
 
@@ -190,6 +190,8 @@ use const STDOUT;
  */
 class Writer
 {
+    use InflectsString;
+
     /** @var resource Output file handle */
     protected $stream;
 
@@ -339,7 +341,7 @@ class Writer
 
         $second        = (string) $second;
         $terminalWidth = $this->terminal->width() ?? 80;
-        $dashWidth     = $terminalWidth - (mb_strwidth($first) + mb_strwidth($second));
+        $dashWidth     = $terminalWidth - ($this->strwidth($first) + $this->strwidth($second));
         // remove left and right margins because we're going to add 1 space on each side (after/before the text).
         // if we don't have a second element, we just remove the left margin
         $dashWidth -= $second === '' ? 1 : 2;

--- a/src/Output/Writer.php
+++ b/src/Output/Writer.php
@@ -339,7 +339,7 @@ class Writer
 
         $second        = (string) $second;
         $terminalWidth = $this->terminal->width() ?? 80;
-        $dashWidth     = $terminalWidth - (strlen($first) + strlen($second));
+        $dashWidth     = $terminalWidth - (mb_strwidth($first) + mb_strwidth($second));
         // remove left and right margins because we're going to add 1 space on each side (after/before the text).
         // if we don't have a second element, we just remove the left margin
         $dashWidth -= $second === '' ? 1 : 2;

--- a/tests/Output/TableTest.php
+++ b/tests/Output/TableTest.php
@@ -639,4 +639,26 @@ class TableTest extends CliTestCase
 
         $this->assertSame($expectedOutput, trim($result));
     }
+
+    public function test_render_with_unicode_characters_in_cell_content(): void
+    {
+        $rows = [
+            ['name' => 'François', 'greeting' => 'Bonjour'],
+            ['name' => 'Jürgen', 'greeting' => 'Guten Tag'],
+            ['name' => '北京', 'greeting' => '你好']
+        ];
+
+        $expectedOutput =
+            "+----------+-----------+" . PHP_EOL .
+            "| Name     | Greeting  |" . PHP_EOL .
+            "+----------+-----------+" . PHP_EOL .
+            "| François | Bonjour   |" . PHP_EOL .
+            "| Jürgen   | Guten Tag |" . PHP_EOL .
+            "| 北京     | 你好      |" . PHP_EOL .
+            "+----------+-----------+";
+
+        $result = $this->table->render($rows);
+
+        $this->assertSame($expectedOutput, trim($result));
+    }
 }

--- a/tests/Output/TableTest.php
+++ b/tests/Output/TableTest.php
@@ -642,6 +642,10 @@ class TableTest extends CliTestCase
 
     public function test_render_with_unicode_characters_in_cell_content(): void
     {
+        if (! extension_loaded('mbstring')) {
+            $this->markTestSkipped('The mbstring extension is not installed. This test will faill without it');
+        }
+
         $rows = [
             ['name' => 'François', 'greeting' => 'Bonjour'],
             ['name' => 'Jürgen', 'greeting' => 'Guten Tag'],


### PR DESCRIPTION
this PR corrects the problem of displaying unicode characters when rendering tables. When you have data with unicode characters in cells, the table columns are not aligned correctly.

**Before**
![image](https://github.com/user-attachments/assets/b64ffd88-41c0-4f22-9ee0-f7f6b6fd5589)

**After**
![image](https://github.com/user-attachments/assets/07e1b708-2e3a-446f-8f5e-8e3e3c999895)

It was the same with the `justify` method.

**Before**
![image](https://github.com/user-attachments/assets/d5fa7afb-7345-4f0d-a928-849a8433a42e)

**After**
![image](https://github.com/user-attachments/assets/d71948fd-e666-4587-97ae-6adbc8ade352)
