### PR TITLE
Allow disabling colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -514,7 +514,6 @@ Ahc\Cli\Output\Color::style('error', [
 Ahc\Cli\Output\Color::$colors_enabled = false;
 ```
 
-
 ### Cursor
 
 Move cursor around, erase line up or down, clear screen.

--- a/README.md
+++ b/README.md
@@ -508,6 +508,13 @@ Ahc\Cli\Output\Color::style('error', [
 ]);
 ```
 
+#### Disable colors
+
+```php
+Ahc\Cli\Output\Color::$colors_enabled = false;
+```
+
+
 ### Cursor
 
 Move cursor around, erase line up or down, clear screen.

--- a/README.md
+++ b/README.md
@@ -511,7 +511,7 @@ Ahc\Cli\Output\Color::style('error', [
 #### Disable colors
 
 ```php
-Ahc\Cli\Output\Color::$colors_enabled = false;
+Ahc\Cli\Output\Color::$enabled = false;
 ```
 
 ### Cursor

--- a/README.md
+++ b/README.md
@@ -514,6 +514,8 @@ Ahc\Cli\Output\Color::style('error', [
 Ahc\Cli\Output\Color::$enabled = false;
 ```
 
+Colors will be automatically disabled if the `NO_COLOR` environment variable is set to true.
+
 ### Cursor
 
 Move cursor around, erase line up or down, clear screen.

--- a/src/Output/Color.php
+++ b/src/Output/Color.php
@@ -50,7 +50,7 @@ class Color
     const GRAY     = 47;
     const DARKGRAY = 100;
 
-    static bool $colors_enabled = true;
+    public static bool $colors_enabled = true;
 
     protected string $format = "\033[:mod:;:fg:;:bg:m:txt:\033[0m";
 

--- a/src/Output/Color.php
+++ b/src/Output/Color.php
@@ -50,7 +50,7 @@ class Color
     const GRAY     = 47;
     const DARKGRAY = 100;
 
-    public static bool $colors_enabled = true;
+    public static bool $enabled = true;
 
     protected string $format = "\033[:mod:;:fg:;:bg:m:txt:\033[0m";
 
@@ -140,7 +140,7 @@ class Color
      */
     public function line(string $text, array $style = []): string
     {
-        if (!self::$colors_enabled) {
+        if (!self::$enabled) {
             return $text;
         }
 
@@ -235,7 +235,7 @@ class Color
         }
 
         if (!method_exists($this, $name)) {
-            if (!self::$colors_enabled) {
+            if (!self::$enabled) {
                 return $text;
             }
 

--- a/src/Output/Color.php
+++ b/src/Output/Color.php
@@ -235,11 +235,11 @@ class Color
         }
 
         if (!method_exists($this, $name)) {
-            if (self::$colors_enabled) {
-                throw new InvalidArgumentException(sprintf('Style "%s" not defined', $name));
+            if (!self::$colors_enabled) {
+                return $text;
             }
 
-            return $text;
+            throw new InvalidArgumentException(sprintf('Style "%s" not defined', $name));
         }
 
         return $this->{$name}($text, $style);

--- a/src/Output/Color.php
+++ b/src/Output/Color.php
@@ -50,6 +50,8 @@ class Color
     const GRAY     = 47;
     const DARKGRAY = 100;
 
+    static bool $colors_enabled = true;
+
     protected string $format = "\033[:mod:;:fg:;:bg:m:txt:\033[0m";
 
     /** @var array Custom styles */
@@ -138,6 +140,10 @@ class Color
      */
     public function line(string $text, array $style = []): string
     {
+        if (!self::$colors_enabled) {
+            return $text;
+        }
+
         $style += ['bg' => null, 'fg' => static::WHITE, 'bold' => 0, 'mod' => null];
 
         $format = $style['bg'] === null

--- a/src/Output/Color.php
+++ b/src/Output/Color.php
@@ -140,7 +140,7 @@ class Color
      */
     public function line(string $text, array $style = []): string
     {
-        if (!self::$enabled) {
+        if (!self::$enabled || getenv('NO_COLOR')) {
             return $text;
         }
 
@@ -235,7 +235,7 @@ class Color
         }
 
         if (!method_exists($this, $name)) {
-            if (!self::$enabled) {
+            if (!self::$enabled || getenv('NO_COLOR')) {
                 return $text;
             }
 

--- a/src/Output/Color.php
+++ b/src/Output/Color.php
@@ -235,7 +235,11 @@ class Color
         }
 
         if (!method_exists($this, $name)) {
-            throw new InvalidArgumentException(sprintf('Style "%s" not defined', $name));
+            if (self::$colors_enabled) {
+                throw new InvalidArgumentException(sprintf('Style "%s" not defined', $name));
+            }
+
+            return $text;
         }
 
         return $this->{$name}($text, $style);


### PR DESCRIPTION
Just a tiny implementation that allows us to disable colors:

```php
$command = new Ahc\Cli\Input\Command('test', 'My Test Command');

$command
  ->option('-n --no-colors', 'Disables terminal colors')
  ->parse(['thisfile.php', '--no-colors']);

if (!$this->colors) {
  Ahc\Cli\Output\Color::$enabled = false;
}
```